### PR TITLE
Fix Ruby version dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-slim
+FROM ruby:2.3.6-slim
 
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential nodejs

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.3'
+ruby '2.3.6'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")


### PR DESCRIPTION
The original `FROM ruby:2.3-slim` line will automatically load the latest patch version of Ruby. At the moment it's `2.3.6`, but the Gemfile specifies 2.3.3, so an error is thrown.

I just specified v2.3.6 both in the Gemfile and in the Dockerfile so any future updates shouldn't throw an error 