### PR TITLE
Fix travis & sync ruby version for docker/gems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,27 +3,8 @@ language: ruby
 services:
   - docker
 
-env:
-  global:
-    - DOCKER_VERSION=17.03.0~ce-0~ubuntu-trusty
-    - DOCKER_COMPOSE_VERSION=1.11.2
-
 before_install:
-  - # Once travis pre-installs newer versions of docker & docker compose, the following can be removed
-  - # However, saves a lot of complexity by starting with their docker services configured & then calling these updates.
   - docker -v
-  - docker-compose -v
-  - # List docker-engine versions
-  - apt-cache madison docker-engine
-  - # Update docker
-  - sudo apt-get install docker-engine=${DOCKER_VERSION}
-  - docker -v
-  - docker-compose -v
-
-  - # Update docker compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
   - docker-compose -v
 
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-slim
+FROM ruby:2.3.6-slim
 
 RUN apt-get update && apt-get install -qq -y --no-install-recommends \
       build-essential nodejs

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.3'
+ruby '2.3.6'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")


### PR DESCRIPTION
Looks like travis now supports versions of required docker and docker compose, and ruby version needed to locked/synced for docker/gems.